### PR TITLE
Add information about joining Slack directly, calendar, and monthly meetings

### DIFF
--- a/content/docs/about/join.md
+++ b/content/docs/about/join.md
@@ -21,4 +21,4 @@ We are excited to invite AI practitioners from diverse backgrounds to join LeMat
 
 In general, we expect applicants to be affiliated with a research organization (either in academia or industry) and work on the technical/ethical/legal aspects of LLMs for coding applications.
 
-You can apply [here](https://forms.gle/KvZLmo12Ps7252gi9) to LeMaterial!
+You can apply [here](https://forms.gle/KvZLmo12Ps7252gi9) to LeMaterial! You may also join our Slack channel for communication [here](https://join.slack.com/t/lematerial/shared_invite/zt-2ympg7n9w-2JlSYfNqE7e6ptsigg6WYQ). Additionally, you may add our Google calendar [here](https://calendar.google.com/calendar/u/0?cid=Y183NTM1YTFkNGFlNDQxY2I5MGRjMDE5MWIzZjRkNDYyNjVhYzVjOTRmMzk5MjE3MjNkYWMwMTViNzg5NDYyMGQ2QGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20). We will have monthly discussions regarding features, bugs and new development. Discussions will be held on the second Thursday of the Month at 6pm Paris time (9am Los Angeles time). The next event will be on February 13th.


### PR DESCRIPTION
## Summary

Add the following information on the join page:
- Slack join link
- Calendar link
- Monthly meeting times
- Next monthly meeting
