### PR TITLE
reading-group: update April 8 session details

### DIFF
--- a/data/reading-group/next_session.yaml
+++ b/data/reading-group/next_session.yaml
@@ -11,7 +11,7 @@
   description: |
     We introduce Zatom-1, a multimodal foundation model for 3D small molecules and materials that generates realistic molecules, thermodynamically stable materials, and valid metal-organic frameworks while achieving competitive performance for PoseBusters and LeMat-GenBench. By pretraining across multiple atomistic modalities with a self-supervised generative flow matching objective, we demonstrate the first case of positive predictive transfer learning where modeling materials enhances molecular property prediction accuracy for downstream tasks like QM9 and Matbench. Zatom-1 is powered by an approximately equivariant transformer architecture that scales effectively in ambient space and outperforms existing equivariant and latent generative models.
 - title: "Leveraging Hidden-Space Representations Effectively in Bayesian Optimization for Experiment Design through Dimension-Aware Hyperpriors"
-  speaker: "Maximilian Fleck"
+  speaker: "Guanming Chen, Maximilian Fleck, Thijs Stuyver"
   date: "Wednesday, April 8th, 2026"
   date_iso: "2026-04-08"
   time: "08:30 AM PT / 11:30 PM ET / 5:30 PM CET"
@@ -19,6 +19,14 @@
   paper_link: "https://chemrxiv.org/doi/full/10.26434/chemrxiv.10001986/v2"
   # image_url: 
   meeting_link: "https://meet.google.com/hcg-szpf-ibh"
-  # calendar_link: ""
-  # description: |
-  #   We introduce Zatom-1, a multimodal foundation model for 3D small molecules and materials that generates realistic molecules, thermodynamically stable materials, and valid metal-organic frameworks while achieving competitive performance for PoseBusters and LeMat-GenBench. By pretraining across multiple atomistic modalities with a self-supervised generative flow matching objective, we demonstrate the first case of positive predictive transfer learning where modeling materials enhances molecular property prediction accuracy for downstream tasks like QM9 and Matbench. Zatom-1 is powered by an approximately equivariant transformer architecture that scales effectively in ambient space and outperforms existing equivariant and latent generative models.
+  calendar_link: "https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=b2NoZ2sycHJhMmhjOXRzOTlzdDRqY3Z2cmdfMjAyNjA0MDhUMTUzMDAwWiBkMjJlZGU4ZWNmYmE1YWFiZWMyZmYzNmI3Y2VmYTdkYTNjY2QxZmNiNjFiYjJlNDQxMjg4MjlmZDgwYzIwMjYyQGc&tmsrc=d22ede8ecfba5aabec2ff36b7cefa7da3ccd1fcb61bb2e44128829fd80c20262%40group.calendar.google.com"
+  description: |
+    Hidden-space features (HSFs) of molecules, which are derived from pre-trained graph neural networks, Transformer models and large language models, offer an appealing alternative to conventional encodings for Bayesian optimisation (BO) in chemical experiment design. This talk explores how mismatched Gaussian process hyperpriors, rather than the representations themselves, can limit the effectiveness of HSFs in BO, and introduces a dimension-aware adaptive prior that maximises their potential in chemical experiment design.
+
+    **Speakers**
+
+    Guanming Chen is a second-year PhD student at Chimie ParisTech under the supervision of Prof. Thijs Stuyver. His research focuses on exploring latent representations derived from pretrained machine learning models and their applications to predictive chemistry and experiment design via Bayesian optimization.
+
+    Maximilian Fleck is a Research Engineer and Data Steward within the ChemAI Grand Programme with research focus on experimental design via Bayesian optimization, physically inspired machine learning, research data management, physical chemistry and thermodynamics.
+
+    Thijs Stuyver is a Junior Professor at Chimie ParisTech (ENSCP-PSL), where his research focuses on theoretical chemistry and ML for chemical reactivity discovery, including Bayesian optimization and surrogate models for data-efficient predictive chemistry.


### PR DESCRIPTION
## Summary

This PR updates the April 8, 2026 reading-group session entry.

## Changes

- expands the speaker list from a single speaker to the full set of presenters
- adds the calendar invite link for the session
- fills in the session description and speaker bios

## Testing

- [x] Content-only change
